### PR TITLE
Switch to comparing types using type values over string values

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -1,7 +1,7 @@
 #let parse_dotenv(ctx) = {
-  if type(ctx) == "content" {
+  if type(ctx) == content {
     ctx = ctx.text
-  } else if type(ctx) != "string" {
+  } else if type(ctx) != str {
     return ctx
   }
 


### PR DESCRIPTION
In the recently released Typst 0.13, the following warning is printed for the package:

```text
warning: comparing strings with types is deprecated
  ┌─ @preview/tenv:0.1.1/lib.typ:2:5
  │
2 │   if type(ctx) == "content" {
  │      ^^^^^^^^^^^^^^^^^^^^^^
  │
  = hint: compare with the literal type instead
  = hint: this comparison will always return `false` in future Typst releases

warning: comparing strings with types is deprecated
  ┌─ @preview/tenv:0.1.1/lib.typ:4:12
  │
4 │   } else if type(ctx) != "string" {
  │             ^^^^^^^^^^^^^^^^^^^^^
  │
  = hint: compare with the literal type instead
  = hint: this comparison will always return `false` in future Typst releases
```

Switching to using type values will resolve the warnings and prevent the behavior from breaking when Typst 0.14 is released.

Refs: https://typst.app/blog/2025/typst-0.13#type-string-compatibility
Refs: https://typst.app/docs/reference/foundations/type/